### PR TITLE
Add search ranking with multi-field scoring

### DIFF
--- a/components/SearchResults.tsx
+++ b/components/SearchResults.tsx
@@ -6,6 +6,9 @@ import EntryCard from "./EntryCard";
 import LoadingSpinner from "./LoadingSpinner";
 import EndOfList from "./EndOfList";
 
+// Entry with search score from API
+type ScoredEntry = Entry & { score: number };
+
 interface SearchResultsProps {
   query: string;
   type?: string;
@@ -17,7 +20,7 @@ export default function SearchResults({
   type,
   tags,
 }: SearchResultsProps) {
-  const [results, setResults] = useState<Entry[]>([]);
+  const [results, setResults] = useState<ScoredEntry[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [hasMore, setHasMore] = useState(true);
@@ -58,7 +61,7 @@ export default function SearchResults({
         }
 
         const data = await response.json();
-        const fetchedResults = data.results as Entry[];
+        const fetchedResults = data.results as ScoredEntry[];
 
         if (reset) {
           setResults(fetchedResults);
@@ -187,7 +190,17 @@ export default function SearchResults({
       {/* Results list */}
       <div className="space-y-4">
         {results.map((entry) => (
-          <EntryCard key={entry._id.toString()} entry={entry} />
+          <div key={entry._id.toString()} className="relative">
+            {/* Score badge - only show when query exists and score > 0 */}
+            {query && entry.score > 0 && (
+              <div className="absolute -top-2 -right-2 z-10">
+                <span className="inline-flex items-center px-2 py-1 text-xs font-medium bg-accent-teal text-dark-bg rounded-full">
+                  Score: {entry.score}
+                </span>
+              </div>
+            )}
+            <EntryCard entry={entry} />
+          </div>
         ))}
       </div>
 

--- a/lib/searchRanking.ts
+++ b/lib/searchRanking.ts
@@ -1,0 +1,226 @@
+import { Entry } from "../types/models";
+
+/**
+ * Search ranking utility for scoring entries against a search query.
+ * Higher scores indicate better matches.
+ *
+ * Priority 1 (Highest): word.name, quote.body, phrase.body, hypothetical.body
+ * Priority 2 (Medium): word.definition, phrase.definition, tags
+ * Priority 3 (Lowest): notes (all types), quote.source
+ */
+
+// Escape special regex characters in search string
+const escapeForRegex = (s: string): string =>
+  s?.replace(/[-/\\^$*+?.()|[\]{}]/g, "\\$&") ?? s;
+
+// ============ MATCHERS ============
+// Each matcher returns true if the field matches the search string
+
+export const exactMatch = (field: string, search: string): boolean =>
+  field.toLowerCase() === search.toLowerCase();
+
+export const startsWith = (field: string, search: string): boolean =>
+  field?.toLowerCase().startsWith(search.toLowerCase()) ?? false;
+
+export const containsWord = (field: string, search: string): boolean =>
+  new RegExp(`\\b${escapeForRegex(search)}\\b`, "i").test(field ?? "");
+
+export const containsSubString = (field: string, search: string): boolean =>
+  field?.toLowerCase().includes(search.toLowerCase()) ?? false;
+
+// ============ FIELD GETTERS ============
+// Type-safe getters that extract fields from entries
+
+type FieldGetter = (entry: Entry) => string | string[] | undefined;
+
+// Priority 1 fields - primary content
+export const getPrimaryField: FieldGetter = (entry) => {
+  switch (entry.type) {
+    case "word":
+      return entry.name;
+    case "phrase":
+      return entry.body;
+    case "quote":
+      return entry.body;
+    case "hypothetical":
+      return entry.body;
+    default:
+      return undefined;
+  }
+};
+
+// Priority 2 fields - definitions
+export const getDefinition: FieldGetter = (entry) => {
+  switch (entry.type) {
+    case "word":
+      return entry.definition;
+    case "phrase":
+      return entry.definition;
+    default:
+      return undefined;
+  }
+};
+
+// Priority 2 fields - tags
+export const getTags: FieldGetter = (entry) => entry.tags;
+
+// Priority 3 fields - notes
+export const getNotes: FieldGetter = (entry) => {
+  if ("notes" in entry) {
+    return entry.notes;
+  }
+  return undefined;
+};
+
+// Priority 3 fields - quote source only
+export const getQuoteSource: FieldGetter = (entry) => {
+  if (entry.type === "quote") {
+    return entry.source;
+  }
+  return undefined;
+};
+
+// ============ RULES ============
+// Rules are ordered by priority - earlier rules give higher scores
+
+type Matcher = (field: string, search: string) => boolean;
+
+interface Rule {
+  getter: FieldGetter;
+  matcher: Matcher;
+  name: string; // For debugging
+}
+
+const rules: Rule[] = [
+  // Priority 1: Primary field with all matchers (exact → startsWith → containsWord → containsSubString)
+  { getter: getPrimaryField, matcher: exactMatch, name: "primary-exact" },
+  { getter: getPrimaryField, matcher: startsWith, name: "primary-startsWith" },
+  {
+    getter: getPrimaryField,
+    matcher: containsWord,
+    name: "primary-containsWord",
+  },
+  {
+    getter: getPrimaryField,
+    matcher: containsSubString,
+    name: "primary-containsSubString",
+  },
+
+  // Priority 2: Definition with 2 matchers
+  {
+    getter: getDefinition,
+    matcher: containsWord,
+    name: "definition-containsWord",
+  },
+
+  // Priority 2: Tags - check if any tag matches search
+  { getter: getTags, matcher: containsSubString, name: "tags-containsSubString" },
+
+  // Priority 2: Definition substring
+  {
+    getter: getDefinition,
+    matcher: containsSubString,
+    name: "definition-containsSubString",
+  },
+
+  // Priority 3: Notes
+  { getter: getNotes, matcher: containsSubString, name: "notes-containsSubString" },
+
+  // Priority 3: Quote source
+  {
+    getter: getQuoteSource,
+    matcher: containsSubString,
+    name: "quoteSource-containsSubString",
+  },
+];
+
+// ============ SCORING ============
+
+/**
+ * Calculate score for a rule based on its position.
+ * Earlier rules (lower index) get higher scores.
+ * Formula: (totalRules - ruleIndex)^2
+ */
+export const ruleScore = (index: number): number =>
+  Math.pow(rules.length - index, 2);
+
+/**
+ * Rank an entry against a search string.
+ * Returns a cumulative score based on all matching rules.
+ */
+export const rankEntry = (entry: Entry, searchString: string): number => {
+  if (!searchString || searchString.trim() === "") {
+    return 0;
+  }
+
+  const normalizedSearch = searchString.toLowerCase().trim();
+
+  const total = rules.reduce((score, rule, index) => {
+    const fieldValue = rule.getter(entry);
+
+    if (fieldValue === undefined || fieldValue === null) {
+      return score;
+    }
+
+    let matches = false;
+
+    if (Array.isArray(fieldValue)) {
+      // For arrays (like tags), check if any element matches
+      matches = fieldValue.some(
+        (val) => val && rule.matcher(val.toLowerCase(), normalizedSearch)
+      );
+    } else if (typeof fieldValue === "string") {
+      matches = rule.matcher(fieldValue.toLowerCase(), normalizedSearch);
+    }
+
+    if (matches) {
+      return score + ruleScore(index);
+    }
+
+    return score;
+  }, 0);
+
+  return total;
+};
+
+/**
+ * Get max possible score (for reference/normalization if needed)
+ */
+export const getMaxPossibleScore = (): number => {
+  return rules.reduce((total, _, index) => total + ruleScore(index), 0);
+};
+
+/**
+ * Get score breakdown for debugging
+ */
+export const getScoreBreakdown = (
+  entry: Entry,
+  searchString: string
+): { rule: string; score: number; matched: boolean }[] => {
+  if (!searchString || searchString.trim() === "") {
+    return [];
+  }
+
+  const normalizedSearch = searchString.toLowerCase().trim();
+
+  return rules.map((rule, index) => {
+    const fieldValue = rule.getter(entry);
+    let matched = false;
+
+    if (fieldValue !== undefined && fieldValue !== null) {
+      if (Array.isArray(fieldValue)) {
+        matched = fieldValue.some(
+          (val) => val && rule.matcher(val.toLowerCase(), normalizedSearch)
+        );
+      } else if (typeof fieldValue === "string") {
+        matched = rule.matcher(fieldValue.toLowerCase(), normalizedSearch);
+      }
+    }
+
+    return {
+      rule: rule.name,
+      score: matched ? ruleScore(index) : 0,
+      matched,
+    };
+  });
+};

--- a/types/models.ts
+++ b/types/models.ts
@@ -76,6 +76,14 @@ export interface HypotheticalEntry extends BaseEntry {
 export type Entry = WordEntry | PhraseEntry | QuoteEntry | HypotheticalEntry;
 
 /**
+ * Entry with search score for ranked results
+ */
+export interface SearchResultEntry {
+  entry: Entry;
+  score: number;
+}
+
+/**
  * Tag model for categorizing entries
  */
 export interface Tag {


### PR DESCRIPTION
## Summary
- Implement weighted ranking system for search results with priority-based field scoring
- Search across all relevant fields (name, body, definition, notes, tags, quote.source)
- Display relevance score badge on search results in UI

## Scoring Strategy

| Priority | Fields | Matchers | Max Score |
|----------|--------|----------|-----------|
| 1 (Highest) | word.name, quote/phrase/hypothetical.body | exact, startsWith, containsWord, containsSubString | 81-36 |
| 2 (Medium) | word/phrase.definition, tags | containsWord, containsSubString | 25-9 |
| 3 (Lowest) | notes (all types), quote.source | containsSubString | 4-1 |

Scores are cumulative - matching multiple rules increases total score.

## Test plan
- [ ] Search for a word that exists as an exact match in `word.name` - should appear first with highest score
- [ ] Search for a term that appears in both `body` and `notes` - body match should score higher
- [ ] Search for a tag name - entries with that tag should get score boost
- [ ] Search with no query but with type/tag filters - should work as before (no ranking)
- [ ] Verify score badge displays correctly on results
- [ ] Test pagination still works correctly with ranked results

## Resources
- Inspired by https://github.com/roadlittledawn/instant-observability-website/blob/main/src/utils/searchRanking.ts

🤖 Generated with [Claude Code](https://claude.com/claude-code)